### PR TITLE
detekt で例外の握りつぶしを報告する

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(19)
+    jvmToolchain(21)
 }
 
 tasks.withType<Test>().configureEach {

--- a/src/main/kotlin/org/example/detekt/IgnoreExceptionRule.kt
+++ b/src/main/kotlin/org/example/detekt/IgnoreExceptionRule.kt
@@ -1,0 +1,4 @@
+package org.example.detekt
+
+class IgnoreExceptionRule {
+}

--- a/src/main/kotlin/org/example/detekt/IgnoreExceptionRule.kt
+++ b/src/main/kotlin/org/example/detekt/IgnoreExceptionRule.kt
@@ -1,4 +1,35 @@
 package org.example.detekt
 
-class IgnoreExceptionRule {
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
+
+class IgnoreExceptionRule(config: Config) : Rule(config) {
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "This rule reports ignored exceptions in catch block",
+        Debt.FIVE_MINS,
+    )
+
+    override fun visitCatchSection(catchClause: KtCatchClause) {
+        super.visitCatchSection(catchClause)
+        // if empty catch block then default to report
+        val catchBody = catchClause.catchBody ?: return
+
+        val hasIf = catchBody.anyDescendantOfType<KtIfExpression>()
+        val hasWhen = catchBody.anyDescendantOfType<KtWhenExpression>()
+
+        val lastStatement = catchBody.lastBlockStatementOrThis()
+        if ((hasIf || hasWhen) && lastStatement !is KtThrowExpression) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(catchClause),
+                    "Exception is ignored"
+                )
+            )
+        }
+    }
 }

--- a/src/test/kotlin/org/example/detekt/IgnoreExceptionRuleTest.kt
+++ b/src/test/kotlin/org/example/detekt/IgnoreExceptionRuleTest.kt
@@ -50,6 +50,25 @@ internal class IgnoreExceptionRuleTest(private val env: KotlinCoreEnvironment) {
     }
 
     @Test
+    fun `should not report when return before pass catch block`() {
+        // language=kotlin
+        val code = """
+            fun test() {
+                try {
+                    throw Exception()
+                } catch (e: Exception) {
+                    when (e) {
+                        is NumberFormatException -> println("handle exception")
+                    }
+                    return
+                }
+            }
+        """
+        val findings = IgnoreExceptionRule(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
+
+    @Test
     fun `should report ignored exceptions in catch block with if expression`() {
         // language=kotlin
         val code = """

--- a/src/test/kotlin/org/example/detekt/IgnoreExceptionRuleTest.kt
+++ b/src/test/kotlin/org/example/detekt/IgnoreExceptionRuleTest.kt
@@ -1,0 +1,5 @@
+package org.example.detekt
+
+import org.junit.jupiter.api.Assertions.*
+
+class IgnoreExceptionRuleTest

--- a/src/test/kotlin/org/example/detekt/IgnoreExceptionRuleTest.kt
+++ b/src/test/kotlin/org/example/detekt/IgnoreExceptionRuleTest.kt
@@ -1,5 +1,132 @@
 package org.example.detekt
 
-import org.junit.jupiter.api.Assertions.*
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Test
 
-class IgnoreExceptionRuleTest
+@KotlinCoreEnvironmentTest
+internal class IgnoreExceptionRuleTest(private val env: KotlinCoreEnvironment) {
+
+    @Test
+    fun `should not report when exceptions is thrown (if)`() {
+        // language=kotlin
+        val code = """
+            fun test() {
+                try {
+                    throw Exception()
+                } catch (e: Exception) {
+                    if (e is NumberFormatException) {
+                        println("handle exception")
+                    }
+                    throw e
+                }
+            }
+        """
+        val findings = IgnoreExceptionRule(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
+
+    @Test
+    fun `should not report when exceptions is thrown (when)`() {
+        // language=kotlin
+        val code = """
+            fun test() {
+                try {
+                    throw Exception()
+                } catch (e: Exception) {
+                    when (e) {
+                        is NumberFormatException -> println("handle exception")
+                    }
+                    throw e
+                }
+            }
+        """
+        val findings = IgnoreExceptionRule(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
+
+    @Test
+    fun `should report ignored exceptions in catch block with if expression`() {
+        // language=kotlin
+        val code = """
+            fun test() {
+                try {
+                    throw Exception()
+                } catch (e: Exception) {
+                    if (e is NumberFormatException) {
+                        println("handle exception")
+                    }
+                    println("Exception is ignored")
+                }
+            }
+        """
+        val findings = IgnoreExceptionRule(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+        findings[0].message shouldBe "Exception is ignored"
+    }
+
+    @Test
+    fun `should report ignored exceptions in catch block with when expression`() {
+        // language=kotlin
+        val code = """
+            fun test() {
+                try {
+                    throw Exception()
+                } catch (e: Exception) {
+                    when (e) {
+                        is NumberFormatException -> println("handle exception")
+                    }
+                    println("Exception is ignored")
+                }
+            }
+        """
+        val findings = IgnoreExceptionRule(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+        findings[0].message shouldBe "Exception is ignored"
+    }
+
+    @Test
+    fun `should report when exceptions is thrown in if expression and not thrown in outside the block`() {
+        // language=kotlin
+        val code = """
+            fun test() {
+                try {
+                    throw Exception()
+                } catch (e: Exception) {
+                    if (e is NumberFormatException) {
+                        throw e
+                    }
+                    println("Exception is ignored")
+                }
+            }
+        """
+        val findings = IgnoreExceptionRule(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+        findings[0].message shouldBe "Exception is ignored"
+    }
+
+    @Test
+    fun `should report when exceptions is thrown in when expression and not thrown in outside the block`() {
+        // language=kotlin
+        val code = """
+            fun test() {
+                try {
+                    throw Exception()
+                } catch (e: Exception) {
+                    when (e) {
+                        is NumberFormatException -> throw e
+                    }
+                    println("Exception is ignored")
+                }
+            }
+        """
+        val findings = IgnoreExceptionRule(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+        findings[0].message shouldBe "Exception is ignored"
+    }
+
+}


### PR DESCRIPTION
- catch が空のブロックはデフォルトのルールで報告される
- 以下の条件を満たす場合に報告する
- catch 内に分岐がある
- catch の分岐外（最終行）で 、例外を throw もしくは return していない
```
try {
                    throw Exception()
                } catch (e: Exception) {
                    if (e is NumberFormatException) {
                        println("handle exception")
                    }
                    println("Exception is ignored")
                }
```
